### PR TITLE
Renew/Return licenses

### DIFF
--- a/r2-testapp/src/main/java/org/readium/r2/testapp/DRMManagementActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/DRMManagementActivity.kt
@@ -12,10 +12,12 @@ package org.readium.r2.testapp
 
 import android.graphics.Typeface
 import android.os.Bundle
+import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.Gravity
 import android.widget.LinearLayout
 import org.jetbrains.anko.*
+import org.jetbrains.anko.appcompat.v7.Appcompat
 import org.jetbrains.anko.design.coordinatorLayout
 import org.jetbrains.anko.sdk25.coroutines.onClick
 import org.joda.time.DateTime
@@ -224,23 +226,71 @@ class DRMManagementActivity : AppCompatActivity() {
                     button {
                         text = context.getString(R.string.drm_label_renew)
                         onClick {
-                            lcpLicense.renewLicense() {renewedLicense ->
-                                val renewedLicense = renewedLicense  as LicenseDocument
-                                // TODO refresh UI
-                                // TODO update license archive
+                            val renewAlert = alert(Appcompat, "The publication will be valid for one more week") {
 
+                                positiveButton("Renew") { }
+                                negativeButton("Cancel") { }
+
+                            }.build()
+                            renewAlert.apply {
+                                setCancelable(false)
+                                setCanceledOnTouchOutside(false)
+                                setOnShowListener {
+                                    val button = getButton(AlertDialog.BUTTON_POSITIVE)
+                                    button.setOnClickListener {
+                                        lcpLicense.renewLicense() {renewedLicense ->
+                                            val renewedLicense = renewedLicense as LicenseDocument
+
+                                            //TODO : correctly set new end date
+                                            lcpLicense.license = renewedLicense
+
+                                            renewAlert.dismiss()
+                                            finish()
+                                            startActivity(intent)
+                                        }
+
+                                    }
+                                    val cancelButton = getButton(AlertDialog.BUTTON_NEGATIVE)
+                                    cancelButton.setOnClickListener {
+                                        renewAlert.dismiss()
+                                    }
+                                }
                             }
+                            renewAlert.show()
                         }
                     }.lparams(width = matchParent, height = wrapContent, weight = 1f)
                     button {
                         text = context.getString(R.string.drm_label_return)
                         onClick {
-                            lcpLicense.returnLicense() { returnedLicense ->
-                                val returnedLicense = returnedLicense  as LicenseDocument
-                                // TODO refresh UI
-                                // TODO update license archive
+                            val returnAlert = alert(Appcompat, "This will return the publication") {
 
+                                positiveButton("Return") { }
+                                negativeButton("Cancel") { }
+
+                            }.build()
+                            returnAlert.apply {
+                                setCancelable(false)
+                                setCanceledOnTouchOutside(false)
+                                setOnShowListener {
+                                    val button = getButton(AlertDialog.BUTTON_POSITIVE)
+                                    button.setOnClickListener {
+                                        lcpLicense.returnLicense() { returnedLicense ->
+                                            val returnedLicense = returnedLicense as LicenseDocument
+
+                                            lcpLicense.license = returnedLicense
+
+                                            setResult(1)
+                                            returnAlert.dismiss()
+                                            finish()
+                                        }
+                                    }
+                                    val cancelButton = getButton(AlertDialog.BUTTON_NEGATIVE)
+                                    cancelButton.setOnClickListener {
+                                        returnAlert.dismiss()
+                                    }
+                                }
                             }
+                            returnAlert.show()
                         }
                     }.lparams(width = matchParent, height = wrapContent, weight = 1f)
                 }

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/DRMManagementActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/DRMManagementActivity.kt
@@ -35,6 +35,8 @@ class DRMManagementActivity : AppCompatActivity() {
 
         val drmModel: DRMModel = intent.getSerializableExtra("drmModel") as DRMModel
         val lcpLicense = LcpLicense(drmModel.licensePath,true , this)
+        lcpLicense.fetchStatusDocument().get()
+        lcpLicense.updateLicenseDocument().get()
 
         coordinatorLayout {
             fitsSystemWindows = true

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/DRMManagementActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/DRMManagementActivity.kt
@@ -234,7 +234,7 @@ class DRMManagementActivity : AppCompatActivity() {
                     button {
                         text = context.getString(R.string.drm_label_renew)
                         onClick {
-                            if (renewURL != null && renewURLType == "text/html") {
+                            if (renewURLType == "text/html") {
                                 val intent = Intent(Intent.ACTION_VIEW)
                                 intent.data = Uri.parse(renewURL)
                                 startActivity(intent)

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/R2EpubActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/R2EpubActivity.kt
@@ -10,6 +10,7 @@
 
 package org.readium.r2.testapp
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.Gravity
@@ -99,8 +100,10 @@ class R2EpubActivity : R2EpubActivity() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (resultCode == 1) {
-            finish()
+        if (requestCode == 1 && resultCode == Activity.RESULT_OK) {
+            if (data != null && data.getBooleanExtra("returned", false)) {
+                finish()
+            }
         }
     }
 

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/R2EpubActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/R2EpubActivity.kt
@@ -64,7 +64,7 @@ class R2EpubActivity : R2EpubActivity() {
                 return true
             }
             R.id.drm -> {
-                startActivity(intentFor<DRMManagementActivity>("drmModel" to drmModel))
+                startActivityForResult(intentFor<DRMManagementActivity>("drmModel" to drmModel), 1)
                 return true
             }
             R.id.bookmark -> {
@@ -86,7 +86,7 @@ class R2EpubActivity : R2EpubActivity() {
                     }
                 } ?: run {
                     runOnUiThread {
-                        toast("Bookmark already exist")
+                        toast("Bookmark already exists")
                     }
                 }
 
@@ -96,6 +96,12 @@ class R2EpubActivity : R2EpubActivity() {
             else -> return false
         }
 
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (resultCode == 1) {
+            finish()
+        }
     }
 
 


### PR DESCRIPTION
fixes #98 

A user is now able to renew and/or return its publications. The loan new end date (in case of a renewing action) is at the moment set by the server (the user can't yet define until when)