### PR TITLE
Fix issue #195 : screen brightness

### DIFF
--- a/r2-testapp/src/main/java/org/readium/r2/testapp/UserSettings.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/UserSettings.kt
@@ -70,6 +70,12 @@ class UserSettings(var preferences: SharedPreferences, val context: Context, val
         pageMargins = preferences.getFloat(PAGE_MARGINS_REF, pageMargins)
         lineHeight = preferences.getFloat(LINE_HEIGHT_REF, lineHeight)
         userProperties = getUserSettings()
+
+        //Setting up screen brightness
+        val backLightValue = preferences.getInt("reader_brightness", 50).toFloat() / 100
+        val layoutParams = (context as R2EpubActivity).window.attributes
+        layoutParams.screenBrightness = backLightValue
+        context.window.attributes = layoutParams
     }
 
     private fun getUserSettings(): UserProperties {
@@ -539,12 +545,6 @@ class UserSettings(var preferences: SharedPreferences, val context: Context, val
         // Brightness
         val brightnessSeekbar = layout.findViewById(R.id.brightness) as SeekBar
         val brightness = preferences.getInt("reader_brightness", 50)
-        run {
-            val backLightValue = brightness.toFloat() / 100
-            val layoutParams = (context as R2EpubActivity).window.attributes
-            layoutParams.screenBrightness = backLightValue
-            context.window.attributes = layoutParams
-        }
         brightnessSeekbar.progress = brightness
         brightnessSeekbar.setOnSeekBarChangeListener(
                 object : SeekBar.OnSeekBarChangeListener {


### PR DESCRIPTION
Previously the brightness was adjusted in the function "userSettingsPopUp" (UserSettings.kt)  which was only called when user clicked on settings button. This is why the brightness was only adjusted when user clicked on settings button.
To fix this issue screen brightness is now adjusted in UserSettings's init method.
 [Issue #195](https://github.com/readium/r2-testapp-kotlin/issues/195#issue-430009350)

fixes https://github.com/readium/r2-testapp-kotlin/issues/195