### PR TITLE
disable Android rotation management (destruction and recreation)

### DIFF
--- a/r2-testapp/src/main/AndroidManifest.xml
+++ b/r2-testapp/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
         android:usesCleartextTraffic="true"
         tools:replace="android:allowBackup"
         tools:targetApi="m">
-        <activity android:name=".CatalogActivity">
+        <activity android:name=".CatalogActivity"
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Fixes a bug where rotating while adding a book will stop the process.