### PR TITLE
Use the PublicationRepository to fix the TransactionTooLargeException

### DIFF
--- a/r2-testapp/src/main/java/org/readium/r2/testapp/audiobook/AudiobookActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/audiobook/AudiobookActivity.kt
@@ -16,9 +16,8 @@ import org.jetbrains.anko.toast
 import org.readium.r2.navigator.Navigator
 import org.readium.r2.navigator.NavigatorDelegate
 import org.readium.r2.navigator.audiobook.R2AudiobookActivity
+import org.readium.r2.shared.extensions.putPublicationFrom
 import org.readium.r2.shared.publication.Locator
-import org.readium.r2.shared.publication.indexOfFirstWithHref
-import org.readium.r2.shared.publication.putPublicationFrom
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.db.Bookmark
 import org.readium.r2.testapp.db.BookmarksDatabase
@@ -101,7 +100,7 @@ class AudiobookActivity : R2AudiobookActivity(), NavigatorDelegate {
 
             R.id.toc -> {
                 val intent = Intent(this, R2OutlineActivity::class.java).apply {
-                    putPublicationFrom(intent)
+                    putPublicationFrom(this@AudiobookActivity)
                     putExtra("bookId", bookId)
                 }
                 startActivityForResult(intent, 2)

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/audiobook/AudiobookActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/audiobook/AudiobookActivity.kt
@@ -18,6 +18,7 @@ import org.readium.r2.navigator.NavigatorDelegate
 import org.readium.r2.navigator.audiobook.R2AudiobookActivity
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.indexOfFirstWithHref
+import org.readium.r2.shared.publication.putPublicationFrom
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.db.Bookmark
 import org.readium.r2.testapp.db.BookmarksDatabase
@@ -99,9 +100,10 @@ class AudiobookActivity : R2AudiobookActivity(), NavigatorDelegate {
         when (item.itemId) {
 
             R.id.toc -> {
-                val intent = Intent(this, R2OutlineActivity::class.java)
-                intent.putExtra("publication", publication)
-                intent.putExtra("bookId", bookId)
+                val intent = Intent(this, R2OutlineActivity::class.java).apply {
+                    putPublicationFrom(intent)
+                    putExtra("bookId", bookId)
+                }
                 startActivityForResult(intent, 2)
                 return true
             }

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/comic/ComicActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/comic/ComicActivity.kt
@@ -22,6 +22,7 @@ import org.readium.r2.navigator.cbz.R2CbzActivity
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.indexOfFirstWithHref
 import org.readium.r2.shared.publication.opds.images
+import org.readium.r2.shared.publication.putPublicationFrom
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.db.BooksDatabase
 import org.readium.r2.testapp.library.LibraryActivity
@@ -83,9 +84,10 @@ class ComicActivity : R2CbzActivity(), CoroutineScope, NavigatorDelegate {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.toc -> {
-                val intent = Intent(this, R2OutlineActivity::class.java)
-                intent.putExtra("publication", publication)
-                intent.putExtra("bookId", bookId)
+                val intent = Intent(this, R2OutlineActivity::class.java).apply {
+                    putPublicationFrom(intent)
+                    putExtra("bookId", bookId)
+                }
                 startActivityForResult(intent, 2)
                 true
             }

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/comic/ComicActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/comic/ComicActivity.kt
@@ -19,10 +19,8 @@ import kotlinx.coroutines.Dispatchers
 import org.readium.r2.navigator.Navigator
 import org.readium.r2.navigator.NavigatorDelegate
 import org.readium.r2.navigator.cbz.R2CbzActivity
+import org.readium.r2.shared.extensions.putPublicationFrom
 import org.readium.r2.shared.publication.Locator
-import org.readium.r2.shared.publication.indexOfFirstWithHref
-import org.readium.r2.shared.publication.opds.images
-import org.readium.r2.shared.publication.putPublicationFrom
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.db.BooksDatabase
 import org.readium.r2.testapp.library.LibraryActivity
@@ -85,7 +83,7 @@ class ComicActivity : R2CbzActivity(), CoroutineScope, NavigatorDelegate {
         return when (item.itemId) {
             R.id.toc -> {
                 val intent = Intent(this, R2OutlineActivity::class.java).apply {
-                    putPublicationFrom(intent)
+                    putPublicationFrom(this@ComicActivity)
                     putExtra("bookId", bookId)
                 }
                 startActivityForResult(intent, 2)

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/comic/DiViNaActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/comic/DiViNaActivity.kt
@@ -18,8 +18,8 @@ import android.view.MenuItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.readium.r2.navigator.divina.R2DiViNaActivity
+import org.readium.r2.shared.extensions.putPublicationFrom
 import org.readium.r2.shared.publication.Locator
-import org.readium.r2.shared.publication.putPublicationFrom
 import org.readium.r2.testapp.BuildConfig.DEBUG
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.library.LibraryActivity
@@ -67,7 +67,7 @@ class DiViNaActivity : R2DiViNaActivity(), CoroutineScope {
         return when (item.itemId) {
             R.id.toc -> {
                 val intent = Intent(this, R2OutlineActivity::class.java).apply {
-                    putPublicationFrom(intent)
+                    putPublicationFrom(this@DiViNaActivity)
                     putExtra("bookId", bookId)
                 }
                 startActivityForResult(intent, 2)

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/comic/DiViNaActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/comic/DiViNaActivity.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.readium.r2.navigator.divina.R2DiViNaActivity
 import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.putPublicationFrom
 import org.readium.r2.testapp.BuildConfig.DEBUG
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.library.LibraryActivity
@@ -65,9 +66,10 @@ class DiViNaActivity : R2DiViNaActivity(), CoroutineScope {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.toc -> {
-                val intent = Intent(this, R2OutlineActivity::class.java)
-                intent.putExtra("publication", publication)
-                intent.putExtra("bookId", bookId)
+                val intent = Intent(this, R2OutlineActivity::class.java).apply {
+                    putPublicationFrom(intent)
+                    putExtra("bookId", bookId)
+                }
                 startActivityForResult(intent, 2)
                 true
             }

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
@@ -47,10 +47,9 @@ import org.readium.r2.navigator.epub.Style
 import org.readium.r2.navigator.pager.R2EpubPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.shared.*
-import org.readium.r2.shared.publication.ContentLayout
+import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.epub.EpubLayout
-import org.readium.r2.shared.publication.indexOfFirstWithHref
 import org.readium.r2.shared.publication.presentation.presentation
 import org.readium.r2.testapp.BuildConfig.DEBUG
 import org.readium.r2.testapp.DRMManagementActivity
@@ -211,12 +210,13 @@ class EpubActivity : R2EpubActivity(), CoroutineScope, NavigatorDelegate/*, Visu
                 }
 
                 val locator = searchResult[position]
-                val intent = Intent()
-                intent.putExtra("publicationPath", publicationPath)
-                intent.putExtra("epubName", publicationFileName)
-                intent.putExtra("publication", publication)
-                intent.putExtra("bookId", bookId)
-                intent.putExtra("locator", locator)
+                val intent = Intent().apply {
+                    putPublicationFrom(intent)
+                    putExtra("publicationPath", publicationPath)
+                    putExtra("epubName", publicationFileName)
+                    putExtra("bookId", bookId)
+                    putExtra("locator", locator)
+                }
                 onActivityResult(2, Activity.RESULT_OK, intent)
             }
 
@@ -441,9 +441,10 @@ class EpubActivity : R2EpubActivity(), CoroutineScope, NavigatorDelegate/*, Visu
         when (item.itemId) {
 
             R.id.toc -> {
-                val intent = Intent(this, R2OutlineActivity::class.java)
-                intent.putExtra("publication", publication)
-                intent.putExtra("bookId", bookId)
+                val intent = Intent(this, R2OutlineActivity::class.java).apply {
+                    putPublicationFrom(intent)
+                    putExtra("bookId", bookId)
+                }
                 startActivityForResult(intent, 2)
                 return true
             }

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
@@ -47,6 +47,7 @@ import org.readium.r2.navigator.epub.Style
 import org.readium.r2.navigator.pager.R2EpubPageFragment
 import org.readium.r2.navigator.pager.R2PagerAdapter
 import org.readium.r2.shared.*
+import org.readium.r2.shared.extensions.putPublicationFrom
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.epub.EpubLayout
@@ -211,7 +212,7 @@ class EpubActivity : R2EpubActivity(), CoroutineScope, NavigatorDelegate/*, Visu
 
                 val locator = searchResult[position]
                 val intent = Intent().apply {
-                    putPublicationFrom(intent)
+                    putPublicationFrom(this@EpubActivity)
                     putExtra("publicationPath", publicationPath)
                     putExtra("epubName", publicationFileName)
                     putExtra("bookId", bookId)
@@ -442,7 +443,7 @@ class EpubActivity : R2EpubActivity(), CoroutineScope, NavigatorDelegate/*, Visu
 
             R.id.toc -> {
                 val intent = Intent(this, R2OutlineActivity::class.java).apply {
-                    putPublicationFrom(intent)
+                    putPublicationFrom(this@EpubActivity)
                     putExtra("bookId", bookId)
                 }
                 startActivityForResult(intent, 2)

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
@@ -55,12 +55,12 @@ import org.readium.r2.opds.OPDS1Parser
 import org.readium.r2.opds.OPDS2Parser
 import org.readium.r2.shared.Injectable
 import org.readium.r2.shared.drm.DRM
+import org.readium.r2.shared.extensions.putPublication
 import org.readium.r2.shared.opds.ParseData
 import org.readium.r2.shared.promise
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.epub.pageList
 import org.readium.r2.shared.publication.opds.images
-import org.readium.r2.shared.publication.putPublication
 import org.readium.r2.streamer.container.ContainerError
 import org.readium.r2.streamer.parser.PubBox
 import org.readium.r2.streamer.parser.audio.AudioBookConstant

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
@@ -56,12 +56,11 @@ import org.readium.r2.opds.OPDS2Parser
 import org.readium.r2.shared.Injectable
 import org.readium.r2.shared.drm.DRM
 import org.readium.r2.shared.opds.ParseData
-import org.readium.r2.shared.parsePublication
 import org.readium.r2.shared.promise
 import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.publication.Publication.Companion
 import org.readium.r2.shared.publication.epub.pageList
 import org.readium.r2.shared.publication.opds.images
+import org.readium.r2.shared.publication.putPublication
 import org.readium.r2.streamer.container.ContainerError
 import org.readium.r2.streamer.parser.PubBox
 import org.readium.r2.streamer.parser.audio.AudioBookConstant
@@ -1043,21 +1042,22 @@ open class LibraryActivity : AppCompatActivity(), BooksAdapter.RecyclerViewClick
     }
 
     private fun startActivity(publicationPath: String, book: Book, publication: Publication, coverByteArray: ByteArray? = null) {
-
         val intent = Intent(this, when (publication.type) {
             Publication.TYPE.AUDIO -> AudiobookActivity::class.java
             Publication.TYPE.CBZ -> ComicActivity::class.java
             Publication.TYPE.DiViNa -> DiViNaActivity::class.java
             else -> EpubActivity::class.java
         })
-        intent.putExtra("publicationPath", publicationPath)
-        intent.putExtra("publicationFileName", book.fileName)
-        intent.putExtra("publication", publication)
-        intent.putExtra("bookId", book.id)
-        intent.putExtra("cover", coverByteArray)
+
+        intent.apply {
+            putPublication(publication)
+            putExtra("publicationPath", publicationPath)
+            putExtra("publicationFileName", book.fileName)
+            putExtra("bookId", book.id)
+            putExtra("cover", coverByteArray)
+        }
 
         startActivity(intent)
-
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/opds/OPDSDetailActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/opds/OPDSDetailActivity.kt
@@ -28,7 +28,9 @@ import org.jetbrains.anko.appcompat.v7.Appcompat
 import org.jetbrains.anko.design.snackbar
 import org.jetbrains.anko.support.v4.nestedScrollView
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.getPublication
 import org.readium.r2.shared.publication.opds.images
+import org.readium.r2.shared.publication.destroyPublication
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.db.Book
 import org.readium.r2.testapp.db.BooksDatabase
@@ -53,7 +55,8 @@ class OPDSDetailActivity : AppCompatActivity(), CoroutineScope {
         val database = BooksDatabase(this)
 
         val opdsDownloader = OPDSDownloader(this)
-        val publication: Publication = intent.getParcelableExtra("publication") as Publication
+        val publication: Publication = intent.getPublication(this)
+
         nestedScrollView {
             fitsSystemWindows = true
             lparams(width = matchParent, height = matchParent)
@@ -160,6 +163,12 @@ class OPDSDetailActivity : AppCompatActivity(), CoroutineScope {
                 }
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        intent.destroyPublication()
     }
 
     private fun getDownloadURL(publication: Publication): URL? {

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/opds/OPDSDetailActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/opds/OPDSDetailActivity.kt
@@ -168,7 +168,7 @@ class OPDSDetailActivity : AppCompatActivity(), CoroutineScope {
     override fun onDestroy() {
         super.onDestroy()
 
-        intent.destroyPublication()
+        intent.destroyPublication(this)
     }
 
     private fun getDownloadURL(publication: Publication): URL? {

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/opds/OPDSDetailActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/opds/OPDSDetailActivity.kt
@@ -27,10 +27,10 @@ import org.jetbrains.anko.*
 import org.jetbrains.anko.appcompat.v7.Appcompat
 import org.jetbrains.anko.design.snackbar
 import org.jetbrains.anko.support.v4.nestedScrollView
+import org.readium.r2.shared.extensions.destroyPublication
+import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.publication.getPublication
 import org.readium.r2.shared.publication.opds.images
-import org.readium.r2.shared.publication.destroyPublication
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.db.Book
 import org.readium.r2.testapp.db.BooksDatabase

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/opds/RecyclerViewAdapter.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/opds/RecyclerViewAdapter.kt
@@ -19,9 +19,9 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.mcxiaoke.koi.ext.onClick
 import com.squareup.picasso.Picasso
+import org.readium.r2.shared.extensions.putPublication
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.opds.images
-import org.readium.r2.shared.publication.putPublication
 import org.readium.r2.testapp.R
 
 class RecyclerViewAdapter(private val activity: Activity, private val strings: MutableList<Publication>) : RecyclerView.Adapter<RecyclerViewAdapter.ViewHolder>() {

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/opds/RecyclerViewAdapter.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/opds/RecyclerViewAdapter.kt
@@ -11,6 +11,7 @@
 package org.readium.r2.testapp.opds
 
 import android.app.Activity
+import android.content.Intent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
@@ -18,9 +19,9 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.mcxiaoke.koi.ext.onClick
 import com.squareup.picasso.Picasso
-import org.jetbrains.anko.intentFor
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.opds.images
+import org.readium.r2.shared.publication.putPublication
 import org.readium.r2.testapp.R
 
 class RecyclerViewAdapter(private val activity: Activity, private val strings: MutableList<Publication>) : RecyclerView.Adapter<RecyclerViewAdapter.ViewHolder>() {
@@ -46,7 +47,9 @@ class RecyclerViewAdapter(private val activity: Activity, private val strings: M
         }
 
         viewHolder.itemView.onClick {
-            activity.startActivity(activity.intentFor<OPDSDetailActivity>("publication" to publication))
+            activity.startActivity(Intent(activity, OPDSDetailActivity::class.java).apply {
+                putPublication(publication)
+            })
         }
     }
 

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/outline/R2OutlineActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/outline/R2OutlineActivity.kt
@@ -26,9 +26,7 @@ import kotlinx.android.synthetic.main.item_recycle_highlight.view.*
 import kotlinx.android.synthetic.main.item_recycle_outline.view.*
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import org.readium.r2.shared.publication.Link
-import org.readium.r2.shared.publication.Locator
-import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.epub.landmarks
 import org.readium.r2.shared.publication.epub.pageList
 import org.readium.r2.shared.publication.opds.images
@@ -54,7 +52,7 @@ class R2OutlineActivity : AppCompatActivity() {
         val tabHost = findViewById<TabHost>(R.id.tabhost)
         tabHost.setup()
 
-        val publication = intent.getParcelableExtra("publication") as Publication
+        val publication = intent.getPublication(this)
 
         title = publication.metadata.title
 

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/outline/R2OutlineActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/outline/R2OutlineActivity.kt
@@ -26,6 +26,7 @@ import kotlinx.android.synthetic.main.item_recycle_highlight.view.*
 import kotlinx.android.synthetic.main.item_recycle_outline.view.*
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
+import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.epub.landmarks
 import org.readium.r2.shared.publication.epub.pageList


### PR DESCRIPTION
Fixes #286 

I decided to throw an Exception (and close the Activity in release mode) if an app still uses the old `publication` intent extra. Since apps can crash when loading a big publication, better make sure they are actually upgrading to this new method as soon as possible.

Usage:

```kotlin
// In the source Activity, do:
intent.putPublication(publication)

// And in the target Activity, in onCreate():
val publication = intent.getPublication(this)

// Don't forget to call this in Activity.onDestroy(), to release the Publication:
intent.destroyPublication()
```