### PR TITLE
Fix broken server if a publication file contains special characters

### DIFF
--- a/r2-testapp/src/main/java/org/readium/r2/testapp/epub/R2ScreenReader.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/epub/R2ScreenReader.kt
@@ -16,7 +16,6 @@ import android.speech.tts.UtteranceProgressListener
 import android.widget.Toast
 import org.jsoup.Jsoup
 import org.jsoup.select.Elements
-import org.readium.r2.navigator.BASE_URL
 import org.readium.r2.navigator.IR2TTS
 import org.readium.r2.navigator.VisualNavigator
 import org.readium.r2.shared.publication.Publication
@@ -186,10 +185,12 @@ class R2ScreenReader(var context: Context, var ttsCallbacks: IR2TTS, var navigat
     private fun setUtterances(): Boolean {
         //Load resource as sentences
         utterances = mutableListOf()
-        splitResourceAndAddToUtterances("$BASE_URL:$port/$epubName${items[resourceIndex].href}")
+        val url = Publication.localUrlOf(filename = epubName, port = port, href = items[resourceIndex].href)
+        splitResourceAndAddToUtterances(url)
 
 //        while (++resourceIndex < items.size && utterances.size == 0) {
-//            splitResourceAndAddToUtterances("$BASE_URL:$port/$epubName${items[resourceIndex].href}")
+//            val url = Publication.localUrlOf(filename = epubName, port = port, href = items[resourceIndex].href)
+//            splitResourceAndAddToUtterances(url)
 //        }
 //
 //        if (resourceIndex == items.size)

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/epub/R2SyntheticPageList.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/epub/R2SyntheticPageList.kt
@@ -15,12 +15,13 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.readium.r2.shared.JSONable
 import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Publication
 import org.readium.r2.testapp.db.PositionsDatabase
 import java.net.URI
 import java.net.URL
 
 
-class R2SyntheticPageList(private val positionsDB: PositionsDatabase, private val bookID: Long, private val publicationIdentifier: String) : AsyncTask<Triple<String, String, List<Link>>, String, MutableList<Position>>() {
+class R2SyntheticPageList(private val positionsDB: PositionsDatabase, private val bookID: Long, private val publicationIdentifier: String) : AsyncTask<Triple<Int, String, List<Link>>, String, MutableList<Position>>() {
 
     private val syntheticPageList = mutableListOf<Position>()
     private var pageNumber: Long = 0
@@ -29,7 +30,7 @@ class R2SyntheticPageList(private val positionsDB: PositionsDatabase, private va
         positionsDB.positions.init(bookID)
     }
 
-    override fun doInBackground(vararg p0: Triple<String, String, List<Link>>): MutableList<Position> {
+    override fun doInBackground(vararg p0: Triple<Int, String, List<Link>>): MutableList<Position> {
 
         for (uri in p0) {
             for (i in 0 until uri.third.size) {
@@ -49,7 +50,7 @@ class R2SyntheticPageList(private val positionsDB: PositionsDatabase, private va
         positionsDB.positions.storeSyntheticPageList(bookID, jsonPageList)
     }
 
-    private fun createSyntheticPages(baseURL: String, epubName: String, link: Link) {
+    private fun createSyntheticPages(port: Int, epubName: String, link: Link) {
         val resourceURL: URL
 
         val resourceHref = link.href
@@ -58,7 +59,7 @@ class R2SyntheticPageList(private val positionsDB: PositionsDatabase, private va
         resourceURL = if (URI(resourceHref).isAbsolute) {
             URL(resourceHref)
         } else {
-            URL(baseURL + epubName + resourceHref)
+            URL(Publication.localUrlOf(filename = epubName, port = port, href = resourceHref))
         }
 
         val text: String?

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
@@ -72,7 +72,6 @@ import org.readium.r2.streamer.parser.divina.DiViNaConstant
 import org.readium.r2.streamer.parser.divina.DiViNaParser
 import org.readium.r2.streamer.parser.epub.EPUBConstant
 import org.readium.r2.streamer.parser.epub.EpubParser
-import org.readium.r2.streamer.server.BASE_URL
 import org.readium.r2.streamer.server.Server
 import org.readium.r2.testapp.BuildConfig.DEBUG
 import org.readium.r2.testapp.R
@@ -654,8 +653,8 @@ open class LibraryActivity : AppCompatActivity(), BooksAdapter.RecyclerViewClick
             val syntheticPageList = R2SyntheticPageList(positionsDB, book.id!!, pub.metadata.identifier!!)
 
             when (pub.type) {
-                Publication.TYPE.EPUB -> syntheticPageList.execute(Triple("$BASE_URL:$localPort/", book.fileName!!, pub.readingOrder))
-                Publication.TYPE.WEBPUB -> syntheticPageList.execute(Triple("", book.fileName!!, pub.readingOrder))
+                Publication.TYPE.EPUB -> syntheticPageList.execute(Triple(localPort, book.fileName!!, pub.readingOrder))
+                Publication.TYPE.WEBPUB -> syntheticPageList.execute(Triple(0, book.fileName!!, pub.readingOrder))
                 else -> {
                     //no page list
                 }


### PR DESCRIPTION
Fix #299

The web server was broken if the publication filename contained special characters, e.g. `9+Chemins+Nocturnes+%28Viviane+Hamy%29 copy.epub`. This is fixed by percent-encoding the filename.

We should use the `self` link in `Publication` for the base URL, but unfortunately this doesn't work right now without breaking reading apps, because the `Publication` is serialized before adding the `self` link when serving it in the `Server`. For now, I added `Publication::localBaseUrlOf()` and `Publication::localUrlOf()` to centralize the sanitization code in a single place, until we fix the `self` link issue.