### PR TITLE
Fix launching the navigator

### DIFF
--- a/r2-testapp/src/main/java/org/readium/r2/testapp/audiobook/AudiobookActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/audiobook/AudiobookActivity.kt
@@ -5,11 +5,11 @@ import android.app.ProgressDialog
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
-import android.os.Handler
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.ImageView
 import kotlinx.android.synthetic.main.activity_audiobook.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.anko.indeterminateProgressDialog
 import org.jetbrains.anko.toast
@@ -18,6 +18,7 @@ import org.readium.r2.navigator.NavigatorDelegate
 import org.readium.r2.navigator.audiobook.R2AudiobookActivity
 import org.readium.r2.shared.extensions.putPublicationFrom
 import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.services.isProtected
 import org.readium.r2.testapp.R
 import org.readium.r2.testapp.db.Bookmark
 import org.readium.r2.testapp.db.BookmarksDatabase
@@ -55,21 +56,19 @@ class AudiobookActivity : R2AudiobookActivity(), NavigatorDelegate {
 
         progressDialog = indeterminateProgressDialog(getString(R.string.progress_wait_while_preparing_audiobook))
 
-        Handler().postDelayed({
-            //Setting cover
-            launch {
-                if (intent.hasExtra("cover")) {
-                    val byteArray = intent.getByteArrayExtra("cover")
-                    byteArray?.let {
-                        val bmp = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
-                        findViewById<ImageView>(R.id.imageView).setImageBitmap(bmp)
-                    }
+        //Setting cover
+        launch {
+            delay(100)
+            if (intent.hasExtra("cover")) {
+                val byteArray = intent.getByteArrayExtra("cover")
+                byteArray?.let {
+                    val bmp = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+                    findViewById<ImageView>(R.id.imageView).setImageBitmap(bmp)
                 }
-                menuDrm?.isVisible = intent.getBooleanExtra("drm", false)
             }
-            mediaPlayer?.progress = progressDialog
-
-        }, 100)
+            menuDrm?.isVisible = publication.isProtected
+        }
+        mediaPlayer?.progress = progressDialog
 
 
         // Loads the last read location

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
@@ -34,6 +34,7 @@ import com.google.gson.Gson
 import kotlinx.android.synthetic.main.activity_epub.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.anko.appcompat.v7.coroutines.onClose
 import org.jetbrains.anko.indeterminateProgressDialog
@@ -54,6 +55,7 @@ import org.readium.r2.shared.publication.ContentLayout
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.presentation.presentation
+import org.readium.r2.shared.publication.services.isProtected
 import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.testapp.BuildConfig.DEBUG
 import org.readium.r2.testapp.DRMManagementActivity
@@ -150,11 +152,10 @@ class EpubActivity : R2EpubActivity(), CoroutineScope, NavigatorDelegate/*, Visu
             })
         }
 
-        Handler().postDelayed({
-            launch {
-                menuDrm?.isVisible = intent.getBooleanExtra("drm", false)
-            }
-        }, 100)
+        launch {
+            delay(100)
+            menuDrm?.isVisible = publication.isProtected
+        }
 
         val appearancePref = preferences.getInt(APPEARANCE_REF, 0)
         val backgroundsColors = mutableListOf("#ffffff", "#faf4e8", "#000000")

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/epub/EpubActivity.kt
@@ -233,11 +233,6 @@ class EpubActivity : R2EpubActivity(), CoroutineScope, NavigatorDelegate/*, Visu
         })
         search_listView.adapter = searchResultAdapter
         search_listView.layoutManager = LinearLayoutManager(this)
-
-        // Loads the last read location
-        booksDB.books.currentLocator(bookId)?.let {
-            go(it, false, {})
-        }
     }
 
 

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/library/LibraryActivity.kt
@@ -599,7 +599,6 @@ abstract class LibraryActivity : AppCompatActivity(), BooksAdapter.RecyclerViewC
                             publication = it,
                             bookId = book.id,
                             initialLocator = book.id?.let { id -> booksDB.books.currentLocator(id) },
-                            drm = it.isProtected,
                             deleteOnResult = remoteUrl != null
                         )
                     )

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/utils/NavigatorContract.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/utils/NavigatorContract.kt
@@ -32,7 +32,6 @@ class NavigatorContract : ActivityResultContract<NavigatorContract.Input, Naviga
         val publication: Publication,
         val bookId: Long?,
         val initialLocator: Locator? = null,
-        val drm: Boolean = false,
         val deleteOnResult: Boolean = false
     )
 
@@ -55,7 +54,6 @@ class NavigatorContract : ActivityResultContract<NavigatorContract.Input, Naviga
             putExtra("bookId", input.bookId)
             putExtra("publicationPath", input.file.path)
             putExtra("publicationFileName", input.file.name)
-            putExtra("drm", input.drm)
             putExtra("deleteOnResult", input.deleteOnResult)
             if (input.initialLocator != null) {
                 putExtra("locator", input.initialLocator)

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/utils/NavigatorContract.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/utils/NavigatorContract.kt
@@ -17,6 +17,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import org.readium.r2.shared.extensions.destroyPublication
 import org.readium.r2.shared.extensions.getPublication
 import org.readium.r2.shared.extensions.putPublication
+import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.util.File
 import org.readium.r2.testapp.audiobook.AudiobookActivity
@@ -24,15 +25,24 @@ import org.readium.r2.testapp.comic.ComicActivity
 import org.readium.r2.testapp.comic.DiViNaActivity
 import org.readium.r2.testapp.epub.EpubActivity
 
-class NavigatorContract : ActivityResultContract<NavigatorContract.PublicationData, NavigatorContract.PublicationData>() {
+class NavigatorContract : ActivityResultContract<NavigatorContract.Input, NavigatorContract.Output>() {
 
-    data class PublicationData(
+    data class Input(
+        val file: File,
+        val publication: Publication,
+        val bookId: Long?,
+        val initialLocator: Locator? = null,
+        val drm: Boolean = false,
+        val deleteOnResult: Boolean = false
+    )
+
+    data class Output(
         val file: File,
         val publication: Publication,
         val deleteOnResult: Boolean
     )
 
-    override fun createIntent(context: Context, input: PublicationData): Intent {
+    override fun createIntent(context: Context, input: Input): Intent {
         val intent = Intent(context, when (input.publication.type) {
             Publication.TYPE.AUDIO -> AudiobookActivity::class.java
             Publication.TYPE.CBZ -> ComicActivity::class.java
@@ -42,13 +52,18 @@ class NavigatorContract : ActivityResultContract<NavigatorContract.PublicationDa
 
         return intent.apply {
             putPublication(input.publication)
+            putExtra("bookId", input.bookId)
             putExtra("publicationPath", input.file.path)
             putExtra("publicationFileName", input.file.name)
+            putExtra("drm", input.drm)
             putExtra("deleteOnResult", input.deleteOnResult)
+            if (input.initialLocator != null) {
+                putExtra("locator", input.initialLocator)
+            }
         }
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): PublicationData? {
+    override fun parseResult(resultCode: Int, intent: Intent?): Output? {
         if (intent == null)
             return null
 
@@ -57,7 +72,7 @@ class NavigatorContract : ActivityResultContract<NavigatorContract.PublicationDa
 
         intent.destroyPublication(null)
 
-        return PublicationData(
+        return Output(
             file = File(path),
             publication = intent.getPublication(null),
             deleteOnResult = intent.getBooleanExtra("deleteOnResult", false)


### PR DESCRIPTION
Improves the way navigator activities are launched, and fix the initial locator.

This relates to the PR implementing navigator fragments: https://github.com/readium/r2-navigator-kotlin/pull/148