### PR TITLE
Remove android:usesCleartextTraffic

### DIFF
--- a/r2-testapp/src/main/AndroidManifest.xml
+++ b/r2-testapp/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- android:networkSecurityConfig is required for r2-lcp-kotlin and r2-navigator-kotlin -->
     <application
         android:name=".R2App"
         android:allowBackup="false"
@@ -25,9 +26,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:replace="android:allowBackup"
-        tools:targetApi="m">
+        tools:targetApi="n">
         <activity android:name=".library.LibraryActivity"
             android:clearTaskOnLaunch="true"
             android:configChanges="orientation|screenSize">

--- a/r2-testapp/src/main/res/xml/network_security_config.xml
+++ b/r2-testapp/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+
+        <!--
+        Required with r2-navigator-kotlin
+        Used to serve a publication's resources from the local HTTP server
+        -->
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">localhost</domain>
+
+        <!--
+        Required with r2-lcp-kotlin
+        The CRL is served from an HTTP server, so we need to explicitly allow clear-text traffic on
+        this domain
+        See https://github.com/readium/r2-lcp-kotlin/issues/59
+        -->
+        <domain includeSubdomains="false">crl.edrlab.telesec.de</domain>
+
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Fix https://github.com/readium/r2-testapp-kotlin/issues/337 https://github.com/readium/r2-lcp-kotlin/issues/59

Use a network security config instead of `android:usesCleartextTraffic` to improve network safety.

Unfortunately both `r2-navigator-kotlin` and `r2-lcp-kotlin` require custom network security configs and the build system can't merge two different configs. So for now it's something to be set up in the app and documented.