### PR TITLE
Android 12 fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
@@ -20,7 +19,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         maven { url 'https://jitpack.io' }
         maven { url "https://s3.amazonaws.com/repo.commonsware.com" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
@@ -21,6 +22,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        jcenter()
         maven { url 'https://jitpack.io' }
         maven { url "https://s3.amazonaws.com/repo.commonsware.com" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 
     repositories {
         google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.0'
@@ -19,6 +20,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
         maven { url "https://s3.amazonaws.com/repo.commonsware.com" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }

--- a/r2-testapp/build.gradle
+++ b/r2-testapp/build.gradle
@@ -57,8 +57,8 @@ android {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
     buildFeatures {
-        dataBinding = true
-        viewBinding = true
+        dataBinding true
+        viewBinding true
     }
     buildTypes {
         release {

--- a/r2-testapp/src/main/AndroidManifest.xml
+++ b/r2-testapp/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
         tools:targetApi="n">
         <activity android:name=".MainActivity"
             android:clearTaskOnLaunch="true"
-            android:configChanges="orientation|screenSize">
+            android:configChanges="orientation|screenSize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -43,7 +44,8 @@
             android:name=".utils.R2DispatcherActivity"
             android:launchMode="singleInstance"
             android:noHistory="true"
-            android:theme="@android:style/Theme.NoDisplay">
+            android:theme="@android:style/Theme.NoDisplay"
+            android:exported="true">
 
             <!--
             WARNING: Matching with intent-filters on media types and file extensions is a mess.

--- a/r2-testapp/src/main/java/org/readium/r2/testapp/reader/EpubReaderFragment.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/reader/EpubReaderFragment.kt
@@ -236,9 +236,8 @@ class EpubReaderFragment : VisualReaderFragment(), EpubNavigatorFragment.Listene
             model.cancelSearch()
             menuSearchView.setQuery("", false)
 
-            (activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)?.toggleSoftInput(
-                InputMethodManager.SHOW_FORCED,
-                InputMethodManager.HIDE_IMPLICIT_ONLY
+            (activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)?.showSoftInput(
+                this.view, InputMethodManager.SHOW_FORCED
             )
         }
     }


### PR DESCRIPTION
Two fixes for getting it running on an Android 12 device:

1. Marking activities with intent-filters with `android:exported`
2. Removing `InputMethodManager` `toggleSoftInput` with `showSoftInput`

A few minor things:

1. Having `dataBinding = true` instead of `dataBinding true` generates warnings, so switched that

Closes #410 