### PR TITLE
fix tts speed not used in screen reader

### DIFF
--- a/r2-testapp/src/main/java/org/readium/r2/testapp/tts/ScreenReaderFragment.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/tts/ScreenReaderFragment.kt
@@ -47,7 +47,7 @@ class ScreenReaderFragment : Fragment(), ScreenReaderEngine.Listener {
         super.onCreate(savedInstanceState)
         val activity = requireActivity()
 
-        preferences = activity.getPreferences(Context.MODE_PRIVATE)
+        preferences = activity.getSharedPreferences("org.readium.r2.settings", Context.MODE_PRIVATE)
 
         ViewModelProvider(activity).get(ReaderViewModel::class.java).let {
             publication = it.publication


### PR DESCRIPTION
Code is using getPreferences which uses the classname instead of getSharedPreferences.