### PR TITLE
Fix saving bookmarks' locations

### DIFF
--- a/r2-testapp/src/main/java/org/readium/r2/testapp/bookshelf/BookRepository.kt
+++ b/r2-testapp/src/main/java/org/readium/r2/testapp/bookshelf/BookRepository.kt
@@ -53,10 +53,7 @@ class BookRepository(private val booksDao: BooksDao) {
             resourceHref = locator.href,
             resourceType = locator.type,
             resourceTitle = locator.title.orEmpty(),
-            location = Locator.Locations(
-                progression = locator.locations.progression,
-                position = locator.locations.position
-            ).toJSON().toString(),
+            location = locator.locations.toJSON().toString(),
             locatorText = Locator.Text().toJSON().toString()
         )
 


### PR DESCRIPTION
The PDF navigator relies on the `page=` fragment identifier in a bookmark's `Locator`, but the test app was only saving `position` and `progression` in the database.